### PR TITLE
Reverting back to the original command for installing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
   number: 0
   skip: true  # [py2k]
   skip: true  # [win32]
-  script: pip install . --no-deps
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:


### PR DESCRIPTION
We changed this line to use pip as part of our debugging process, but it did not solve the issue so I am backing it out.